### PR TITLE
Create Script to Ping IP's concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# Joby
-My take-home coding test for Joby Aviation
+# Introduction
+
+My take-home coding test for Joby Aviation.
+
+# Summary
+
+This is a script that pings IPs within a given range concurrently.
+The script uses a predefined IP with its range, generates all
+applicable IPs, and pings them concurrently using multi-threading.
+The script saves the successes and failures of the pings in a
+dictionary, then compares them - if an IP is pingable on one range
+but not the other, that difference is printed out in the comparison.
+
+# Configuration
+
+To change the parameters of the script, edit the constants at the
+top of `joby.py`. The parameters are listed here.
+
+|  **Parameter**   |                                **Purpose**                                | **Type** | **Default Value** |         **Note**          |
+| :--------------: | :-----------------------------------------------------------------------: | :------: | :---------------: | :-----------------------: |
+|    IP_RANGE_1    |                        First range of IPs to ping                         |  String  |  192.168.1.0/24   | IP Address + Subnet Mask  |
+|    IP_RANGE_2    |                        Second range of IPs to ping                        |  String  |  192.168.2.0/24   | IP Address + Subnet Mask  |
+| OCTETS_TO_IGNORE |                         Last octet of IP address                          | [String] |      ["56"]       | Last 8 bits of IP address |
+|   MAX_THREADS    |           Specifies max number of threads this script can spawn           |   int    |        512        |                           |
+|  MAX_QUEUE_SIZE  |         Specifies max length of the queue that IPs are read into          |   int    |        100        |                           |
+|   NUM_RETRIES    | Number of times a ping is retried for an IP before it's counted as a fail |   int    |         2         |                           |

--- a/joby.py
+++ b/joby.py
@@ -3,12 +3,12 @@ from pythonping import ping
 from threading import Thread, Lock
 from queue import Queue
 
-MAX_THREADS = 512
-NUM_RETRIES = 2
-MAX_QUEUE_SIZE = 100
-OCTETS_TO_IGNORE = ["56"]
 IP_RANGE_1 = '192.168.1.0/24'
 IP_RANGE_2 = '192.168.2.0/24'
+OCTETS_TO_IGNORE = ["56"]
+MAX_THREADS = 512
+MAX_QUEUE_SIZE = 100
+NUM_RETRIES = 2
 
 
 class result:

--- a/joby.py
+++ b/joby.py
@@ -12,6 +12,10 @@ IP_RANGE_2 = '192.168.2.0/24'
 
 
 class result:
+    """Store the results of the pings, and have a separate
+        lock for each dictionary
+    """
+
     def __init__(self):
         self.range_1 = self.results_dict_with_mutex()
         self.range_2 = self.results_dict_with_mutex()
@@ -23,6 +27,9 @@ class result:
 
 
 def ping_ip(q, results, retries=1):
+    """Pings the ip received from the queue and
+        stores the result in a thread-safe way
+    """
     while True:
         ip = str(q.get())
         success = False
@@ -33,7 +40,7 @@ def ping_ip(q, results, retries=1):
 
         ip_split = ip.split(".")
 
-        if ip_split[2] == "1":
+        if ip_split[2] == "1":  # Use network ID to separate range
             result = results.range_1
         elif ip_split[2] == "2":
             result = results.range_2
@@ -59,8 +66,8 @@ if __name__ == '__main__':
     ip_queue = Queue(maxsize=MAX_QUEUE_SIZE)
     results = result()
 
-    ping_from_queue(ip_queue=ip_queue, results=results, num_retries=NUM_RETRIES,
-                    max_threads=MAX_THREADS)
+    ping_from_queue(ip_queue=ip_queue, results=results,
+                    num_retries=NUM_RETRIES, max_threads=MAX_THREADS)
 
     for ip in iprange1:
         if str(ip).split(".")[-1] in OCTETS_TO_IGNORE:

--- a/joby.py
+++ b/joby.py
@@ -75,5 +75,13 @@ if __name__ == '__main__':
     ip_queue.join()
 
     for key in results.range_1.ping_success_dict.keys():
-
-        continue
+        if key not in results.range_2.ping_success_dict:
+            continue
+        value_range_1 = results.range_1.ping_success_dict[key]
+        value_range_2 = results.range_2.ping_success_dict[key]
+        if value_range_1 != value_range_2:
+            print("Discrepancy with ip suffix " + key)
+            print("Is IP 192.168.1." + key +
+                  " pingable: " + str(value_range_1) + " \n")
+            print("Is IP 192.168.1." + key +
+                  " pingable: " + str(value_range_2) + " \n")

--- a/joby.py
+++ b/joby.py
@@ -1,0 +1,79 @@
+import ipaddress
+from pythonping import ping
+from threading import Thread, Lock
+from queue import Queue
+
+MAX_THREADS = 512
+NUM_RETRIES = 2
+MAX_QUEUE_SIZE = 100
+OCTETS_TO_IGNORE = ["56"]
+IP_RANGE_1 = '192.168.1.0/24'
+IP_RANGE_2 = '192.168.2.0/24'
+
+
+class result:
+    def __init__(self):
+        self.range_1 = self.results_dict_with_mutex()
+        self.range_2 = self.results_dict_with_mutex()
+
+    class results_dict_with_mutex:
+        def __init__(self):
+            self.lock = Lock()
+            self.ping_success_dict = {}
+
+
+def ping_ip(q, results, retries=1):
+    while True:
+        ip = str(q.get())
+        success = False
+        for i in range(retries):
+            if ping(ip, timeout=2).success():
+                success = True
+                break
+
+        ip_split = ip.split(".")
+
+        if ip_split[2] == "1":
+            result = results.range_1
+        elif ip_split[2] == "2":
+            result = results.range_2
+
+        result.lock.acquire()
+        result.ping_success_dict[ip_split[-1]] = success
+        result.lock.release()
+        q.task_done()
+
+
+def ping_from_queue(ip_queue, results, num_retries, max_threads=255):
+    for i in range(max_threads):
+        t = Thread(target=ping_ip, args=(ip_queue, results, num_retries,))
+        t.setDaemon(True)
+        t.start()
+
+
+if __name__ == '__main__':
+
+    iprange1 = ipaddress.ip_network(IP_RANGE_1)
+    iprange2 = ipaddress.ip_network(IP_RANGE_2)
+
+    ip_queue = Queue(maxsize=MAX_QUEUE_SIZE)
+    results = result()
+
+    ping_from_queue(ip_queue=ip_queue, results=results, num_retries=NUM_RETRIES,
+                    max_threads=MAX_THREADS)
+
+    for ip in iprange1:
+        if str(ip).split(".")[-1] in OCTETS_TO_IGNORE:
+            continue
+        ip_queue.put(ip)
+
+    for ip in iprange2:
+        if str(ip).split(".")[-1] in OCTETS_TO_IGNORE:
+            continue
+        ip_queue.put(ip)
+
+    ip_queue.join()
+
+    for key in results.range_1.ping_success_dict.keys():
+
+        continue


### PR DESCRIPTION
This PR initializes the script to concurrently ping IP's within a given range concurrently. The script uses a predefined IP with its range, generates all applicable IPs, and pings them concurrently using multi-threading. The script saves the successes and failures of the pings in a dictionary, then compares them - if an IP is pingable on one range but not the other, that difference is printed out in the comparison.